### PR TITLE
Adds F2FS support

### DIFF
--- a/prebuilt/vendor/etc/fstab.qcom
+++ b/prebuilt/vendor/etc/fstab.qcom
@@ -5,7 +5,9 @@
 # Currently we dont have e2fsck compiled. So fs check would failed.
 #<src>                                                       <mnt_point>               <type>  <mnt_flags and options>                                                                              <fs_mgr_flags>
 /dev/block/bootdevice/by-name/boot                           /boot                     emmc    defaults                                                                                             defaults
-/dev/block/bootdevice/by-name/userdata                       /data                     ext4    noatime,nosuid,nodev,noatime,barrier=1,noauto_da_alloc,discard                                       wait,check,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata                       /data                     ext4    noatime,nosuid,nodev,noatime,barrier=1,noauto_da_alloc,journal_async_commit,discard,data=writeback,commit=300                                       wait,check,fileencryption=ice,quota,reservedsize=128M
+/dev/block/bootdevice/by-name/userdata                       /data                     f2fs    noatime,nosuid,nodev,nodiratime,fsync_mode=nobarrier,background_gc=off                               latemount,wait,check,formattable,encryptable=footer,quota,reservedsize=128M
+
 /dev/block/bootdevice/by-name/cache                          /cache                    ext4    nosuid,nodev,noatime,barrier=1                                                                       wait,check,formattable
 /dev/block/bootdevice/by-name/misc                           /misc                     emmc    defaults                                                                                             defaults
 /dev/block/bootdevice/by-name/modem                          /vendor/firmware_mnt      vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0         wait
@@ -13,5 +15,5 @@
 /dev/block/bootdevice/by-name/dsp                            /vendor/dsp               ext4    ro,nosuid,nodev,barrier=1                                                                            wait
 /dev/block/bootdevice/by-name/persist                        /mnt/vendor/persist       ext4    noatime,nosuid,nodev,barrier=1                                                                       wait
 
-/dev/block/zram0                                             none                      swap    defaults                                                                                             zramsize=536870912,max_comp_streams=8
+/dev/block/zram0                                             none                      swap    defaults                                                                                             zramsize=1073741824
 /devices/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb* auto                      auto    defaults                                                                                             voldmanaged=usbdisk:auto


### PR DESCRIPTION
Allows for more flexibility of what users can use the Rom as it will now support F2FS. Please add this change, many peo0plle would appreciate it, this commit has been taken from many other Roms including AOSIP and AICP.

https://github.com/DerpFest-OP5T/device_oneplus_msm8998-common/commit/964b299967010b4d89bdc13ebcafffab3734d949
https://github.com/DerpFest-OP5T/device_oneplus_msm8998-common/commit/ceb2c665f7edaa21407bcb3a7e0fb282fee2ce18